### PR TITLE
トップページの検索順位期間を2週間にする

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -6,7 +6,7 @@ class ArticlesController < ApplicationController
   def index
     @articles = current_user.articles
     @today = Date.current
-    @prev_month = Date.current.ago(14.days).to_date
+    @start_date = Date.current.ago(14.days).to_date
   end
 
   def show

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,8 +5,8 @@ class ArticlesController < ApplicationController
 
   def index
     @articles = current_user.articles
-    @today = Time.current.to_date
-    @prev_month = Time.current.prev_month.to_date
+    @today = Date.current
+    @prev_month = Date.current.ago(14.days).to_date
   end
 
   def show

--- a/app/views/articles/index.html.slim
+++ b/app/views/articles/index.html.slim
@@ -12,15 +12,15 @@ table
     tr
       th = Article.human_attribute_name(:id)
       th = Article.human_attribute_name(:keyword)
-      - (@prev_month..@today).each do |date|
-        th = date
+      - (@start_date..@today).each do |date|
+        th = l date, format: :sm
 
   tbody
       - @articles.each do |article|
         tr
           td = article.id
           td = link_to article.keyword, article_path(article)
-          - (@prev_month..@today).each do |date|
+          - (@start_date..@today).each do |date|
             - if article.has_ranking?(date)
               td = article.fetch_ranking(date)
             - else


### PR DESCRIPTION
#46 

## 変更点

トップページに表示していた1ヶ月の検索順位を2週間にした

## 変更理由

- 1ヶ月だと多すぎるため
- 2週間よりも長い期間の順位変動を詳細ページで確認できるため

