### PR TITLE
検索順位が51位以下だと「圏外」と表示する

### DIFF
--- a/app/assets/stylesheets/object/_table.scss
+++ b/app/assets/stylesheets/object/_table.scss
@@ -10,6 +10,7 @@
   td {
     padding: 3px 10px;
     border: 1px solid #ccc;
+    text-align: center;
   }
 }
 

--- a/app/assets/stylesheets/object/_words.scss
+++ b/app/assets/stylesheets/object/_words.scss
@@ -1,0 +1,3 @@
+.str-sm {
+  font-size: .8rem;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,7 +19,7 @@ class ArticlesController < ApplicationController
     @article = current_user.articles.new(article_params)
 
     if @article.save
-      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: ENV["GOOGLE_API_KEY"], cse_id: ENV["GOOGLE_CSE_ID"])
+      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: "mock_api_key", cse_id: "mock_cse_id")
       @article.rankings.create(ranking: google.fetch_ranking, ranked_on: Date.today)
       redirect_to @article, notice: t("success.article_was_successfully_created")
     else

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,7 +19,7 @@ class ArticlesController < ApplicationController
     @article = current_user.articles.new(article_params)
 
     if @article.save
-      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: "mock_api_key", cse_id: "mock_cse_id")
+      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: ENV["GOOGLE_API_KEY"], cse_id: ENV["GOOGLE_CSE_ID"])
       @article.rankings.create(ranking: google.fetch_ranking, ranked_on: Date.today)
       redirect_to @article, notice: t("success.article_was_successfully_created")
     else

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,7 +20,12 @@ class Article < ApplicationRecord
     self.rankings.find_by(ranked_on: date)
   end
 
-  def fetch_ranking(date)
-    self.rankings.find_by(ranked_on: date).ranking
+  def show_ranking(date)
+    ranking = self.rankings.find_by(ranked_on: date).ranking
+    if ranking == 51
+      "圏外"
+    else
+      ranking
+    end
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -13,8 +13,8 @@ table.table
           td = link_to article.keyword, article_path(article)
           - (@start_date..@today).each do |date|
             - if article.has_ranking?(date)
-              td = article.fetch_ranking(date)
+              td = article.show_ranking(date)
             - else
               td = "-"
 
-= link_to t("link.new_article"), new_article_path, class: "btn btn--primary btn--lg"
+= link_to t("link.new_article"), new_article_path, class: "btn--primary btn--lg"

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -17,4 +17,7 @@ table.table
             - else
               td = "-"
 
+p.str-sm
+  | ※51位以下は圏外と表示されます
+
 = link_to t("link.new_article"), new_article_path, class: "btn--primary btn--lg"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Article, type: :model do
   let!(:article_a) { FactoryBot.create(:article, user: user_a) }
   let!(:ranking_a) { FactoryBot.create(:ranking, article: article_a) }
   let!(:ranking_b) { FactoryBot.create(:ranking, ranking: 2, ranked_on: 20200819, article: article_a) }
+  let!(:ranking_51) { FactoryBot.create(:ranking, ranking: 51, ranked_on: 20200821, article: article_a) }
 
   describe "記事の登録" do
     context "urlとkeywordを入力するとき" do
@@ -33,7 +34,8 @@ RSpec.describe Article, type: :model do
       expect(Article.chart(article_a)).to eq(
         {
           "2020-08-20" => 1,
-          "2020-08-19" => 2
+          "2020-08-19" => 2,
+          "2020-08-21" => 51
         })
     end
   end
@@ -42,7 +44,17 @@ RSpec.describe Article, type: :model do
     expect(article_a.has_ranking?(20200820)).to be_truthy
   end
 
-  it "#fetch_ranking" do
-    expect(article_a.fetch_ranking(20200820)).to eq 1
+  describe "#show_ranking" do
+    context "検索順位が50以上のとき" do
+      it "#show_ranking" do
+        expect(article_a.show_ranking(20200820)).to eq 1
+      end
+    end
+
+    context "検索順位が51以下のとき" do
+      it "#show_ranking" do
+        expect(article_a.show_ranking(20200821)).to eq "圏外"
+      end
+    end
   end
 end


### PR DESCRIPTION
50位までしかとらない理由。

- 51位〜100位は、数字的な意味はあっても、どちらにしろ検索結果上では人に見られないため価値が変わらない
- せめて20〜30位以上には入ってこないと効果測定をしようにも対策が立てられない