### PR TITLE
circleCIが通るように修正

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,7 +19,7 @@ class ArticlesController < ApplicationController
     @article = current_user.articles.new(article_params)
 
     if @article.save
-      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: "mock_api_key", cse_id: "mock_cse_id")
+      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: ENV["GOOGLE_API_KEY"], cse_id: ENV["GOOGLE_CSE_ID"])
       @article.rankings.create(ranking: google.fetch_ranking, ranked_on: Date.today)
       redirect_to @article, notice: t("success.article_was_successfully_created")
     else
@@ -29,7 +29,7 @@ class ArticlesController < ApplicationController
 
   def update
     if @article.update(article_params)
-      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: "mock_api_key", cse_id: "mock_cse_id")
+      google = GoogleSearch.new(query: @article.keyword, url: @article.url, api_key: ENV["GOOGLE_API_KEY"], cse_id: ENV["GOOGLE_CSE_ID"])
       @article.rankings.create(ranking: google.fetch_ranking, ranked_on: Date.today)
       redirect_to @article, notice: t("success.article_was_successfully_updated")
     else

--- a/spec/models/google_search_spec.rb
+++ b/spec/models/google_search_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe GoogleSearch, type: :model do
     @google_search = GoogleSearch.new(
       query: "ハンターハンター",
       url: "https://ja.wikipedia.org/wiki/HUNTER%C3%97HUNTER",
-      api_key: "mock_api_key",
-      cse_id: "mock_cse_id"
+      api_key: ENV["GOOGLE_API_KEY"],
+      cse_id: ENV["GOOGLE_CSE_ID"]
     )
   end
 
@@ -25,8 +25,8 @@ RSpec.describe GoogleSearch, type: :model do
         google_search = GoogleSearch.new(
           query: "ハンターハンター",
           url: "https://hoge.com",
-          api_key: "mock_api_key",
-          cse_id: "mock_cse_id"
+          api_key: ENV["GOOGLE_API_KEY"],
+          cse_id: ENV["GOOGLE_CSE_ID"]
         )
         expect(google_search.fetch_ranking).to eq 51
       end

--- a/spec/support/stub_helper.rb
+++ b/spec/support/stub_helper.rb
@@ -11,26 +11,26 @@ module StubHelper
 
   def stub_google_1_to_10!
     json = File.read("#{Rails.root}/spec/factories/files/mock_bodies/search_results_1.json")
-    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=mock_cse_id&key=mock_api_key&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=1").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
+    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=#{ENV["GOOGLE_CSE_ID"]}&key=#{ENV["GOOGLE_API_KEY"]}&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=1").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
   end
 
   def stub_google_11_to_20!
     json = File.read("#{Rails.root}/spec/factories/files/mock_bodies/search_results_2.json")
-    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=mock_cse_id&key=mock_api_key&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=11").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
+    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=#{ENV["GOOGLE_CSE_ID"]}&key=#{ENV["GOOGLE_API_KEY"]}&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=11").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
   end
 
   def stub_google_21_to_30!
     json = File.read("#{Rails.root}/spec/factories/files/mock_bodies/search_results_3.json")
-    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=mock_cse_id&key=mock_api_key&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=21").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
+    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=#{ENV["GOOGLE_CSE_ID"]}&key=#{ENV["GOOGLE_API_KEY"]}&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=21").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
   end
 
   def stub_google_31_to_40!
     json = File.read("#{Rails.root}/spec/factories/files/mock_bodies/search_results_4.json")
-    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=mock_cse_id&key=mock_api_key&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=31").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
+    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=#{ENV["GOOGLE_CSE_ID"]}&key=#{ENV["GOOGLE_API_KEY"]}&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=31").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
   end
 
   def stub_google_41_to_50!
     json = File.read("#{Rails.root}/spec/factories/files/mock_bodies/search_results_5.json")
-    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=mock_cse_id&key=mock_api_key&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=41").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
+    stub_request(:get, "https://customsearch.googleapis.com/customsearch/v1?cx=#{ENV["GOOGLE_CSE_ID"]}&key=#{ENV["GOOGLE_API_KEY"]}&q=%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC%E3%83%8F%E3%83%B3%E3%82%BF%E3%83%BC&start=41").to_return(status: 200, body: json, headers: { "Content-Type" =>  "application/json" })
   end
 end

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "記事管理", type: :system do
     @google_search = GoogleSearch.new(
       query: "ハンターハンター",
       url: "https://ja.wikipedia.org/wiki/HUNTER%C3%97HUNTER",
-      api_key: "mock_api_key",
-      cse_id: "mock_cse_id"
+      api_key: ENV["GOOGLE_API_KEY"],
+      cse_id: ENV["GOOGLE_CSE_ID"]
     )
   end
 


### PR DESCRIPTION
- GoogleSearchクラスの呼び出し部分をCircleCIで通すようにした。
- mock_api_keyやmock_cse_idではなく、ENV[GOOGLE_API_KEY]とENV[GOOGLE_CSE_ID]をセット
- CircleCIにも同様に環境変数をセット（GOOGLE_API_KEY、GOOGLE_CSE_ID）
- テスト環境でGoogleSearch JSON APIにリクエストをするのではなく、スタブを呼び出す