### PR TITLE
記事詳細のURLをハイパーリンクにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "chartkick"
 gem "groupdate"
 gem "google-api-client", "~> 0.34", require: "google/apis/customsearch_v1"
 gem "hanmoto"
+gem "rinku"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,7 @@ GEM
       railties (>= 5.0)
     retriable (3.1.2)
     rexml (3.2.4)
+    rinku (2.0.6)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -341,6 +342,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-i18n
+  rinku
   rspec-rails (~> 4.0.0)
   rubocop
   rubocop-performance

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def url_to_link(text)
-    URI.extract(text, ["http", "https"]).uniq.each do |url|
-      text.gsub!(url, "#{url}")
-    end
-    text
-  end
-
   def ranking_chart(rankings)
     line_chart rankings,
       min: 1,

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -2,7 +2,7 @@ h2.heading-2 記事詳細
 
 h4.heading-4
   = Article.human_attribute_name(:url)
-p = link_to @article.url, target: "_blank", rel: "noopener noreferrer"
+p = raw Rinku.auto_link(h(@article.url), :urls, 'target="_blank" rel="noopener noreferrer"')
 
 h4.heading-4
   = Article.human_attribute_name(:keyword)


### PR DESCRIPTION
## 問題

記事詳細の記事URLをクリックしても該当リンク先へ飛べない。

## 原因

文字列のリンクを`= link_to`ヘルパーに渡して書いていた。

## 解決

Rinku gem を使ってURLの文字列をハイパーリンクにした。